### PR TITLE
Django 1.9 compatibility

### DIFF
--- a/taggit_selectize/urls.py
+++ b/taggit_selectize/urls.py
@@ -4,6 +4,6 @@ from django.conf.urls import *
 
 from .views import get_tags_recommendation
 
-urlpatterns = patterns('',
+urlpatterns = [
     url('^$', get_tags_recommendation, name='tags_recommendation'),
-)
+]


### PR DESCRIPTION
Removing warning:
RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  url('^$', get_tags_recommendation, name='tags_recommendation'),
