### PR TITLE
Fix the item callback to strip quotes when not the first tag

### DIFF
--- a/taggit_selectize/widgets.py
+++ b/taggit_selectize/widgets.py
@@ -49,7 +49,7 @@ class TagSelectize(forms.TextInput):
                                     '</div>';
                                 },
                                 'item': function(item, escape) {
-                                    name = item.name.replace(/^"|"$/g, '');
+                                    name = item.name.replace(/^\s*"|"\s*$/g, '');
                                     return '<div class="item">' + escape(name) + '</div>';
                                 }
                             },


### PR DESCRIPTION
This fixes a problem that crops up when there are multiple multi-word tags, the second+ tag will show up with a quote in it. I fixed this by making the regex accept white space between the beginning of the string and the first quote mark, and then also between the last quote mark and the end of the string. Seems to work in my testing.

BTW, still in absolute love with this module... using it every day and thankful for it every day =)
