### PR TITLE
Allow multiple selectize forms on same page

### DIFF
--- a/taggit_selectize/widgets.py
+++ b/taggit_selectize/widgets.py
@@ -25,7 +25,7 @@ class TagSelectize(forms.TextInput):
             <script type="text/javascript">
                 (function($) {
                     $(document).ready(function() {
-                        $("#%(id)s").selectize({
+                        $("input[id=#%(id)s]").selectize({
                             valueField: 'name',
                             labelField: 'name',
                             searchField: 'name',


### PR DESCRIPTION
If multiple forms exist on the same page, the existing javascript implementation in `widgets.py` will only affect the first instance on the page. This patch fixes the problem.
