### PR TITLE
Add support for Django 2.1

### DIFF
--- a/taggit_selectize/widgets.py
+++ b/taggit_selectize/widgets.py
@@ -12,7 +12,7 @@ except ImportError:
 
 
 class TagSelectize(forms.TextInput):
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value is not None and not isinstance(value, six.string_types):
             value = edit_string_for_tags([o.tag for o in value.select_related("tag")])
         html = super(TagSelectize, self).render(name, value, attrs)


### PR DESCRIPTION
Django 2.1 removed support for Support for Widget.render() methods without the
renderer argument.

I'm not sure if the change is sufficient, but for my use case it makes taggit-selectize work with django 2.1