### PR TITLE
Add a responsivness on the tags editing field #33

### DIFF
--- a/taggit_selectize/static/taggit_selectize/css/selectize.django.css
+++ b/taggit_selectize/static/taggit_selectize/css/selectize.django.css
@@ -318,7 +318,9 @@
 /* Django style, based on default, goal is to fit Django 1.9 flat theme */
 .colM .aligned .selectize-input {
   /* fix alignment in django admin */
-  width: 625px;
+  max-width: 625px;
+  min-width: 200px;
+  width: 100%;
 }
 .selectize-control.plugin-remove_button [data-value] {
   padding-right: 28px !important;


### PR DESCRIPTION
This PR is a partial fix for the #33 issue.

With this little changes we got a responsive field width, which avoid to have, on mobile, a part of the field outside of the viewport.

Min-width to 200px, because sometimes, resizing window made the field didn't fit 100% of the screen and then was set to the minimum size.

Have a great day 👍