### PR TITLE
Fix Django 4.0 deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ And you probably want auto-complete/auto-suggest feature when user types some ch
 
 Features
 --------
-* Supports Django 1.8.x and Django 1.9.x
+* Supports Django >= 2.2
 * Supports >=Python2.7 and >=Python3.4
 * Simple installation, selectize.js 0.12.1 included
 * Will use jQuery install included in Django admin, no installation of jQuery needed

--- a/example_app/example_app/urls.py
+++ b/example_app/example_app/urls.py
@@ -1,21 +1,21 @@
 """example_app URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.8/topics/http/urls/
+    https://docs.djangoproject.com/en/stable/topics/http/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+    2. Add a URL to urlpatterns:  path('', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
 Including another URLconf
-    1. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
+    1. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.contrib import admin
 
 urlpatterns = [
-    url(r'^taggit/', include('taggit_selectize.urls')),
-    url(r'^admin/', include(admin.site.urls)),
+    path('taggit/', include('taggit_selectize.urls')),
+    path('admin/', include(admin.site.urls)),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-django>=1.8.8
+django>=2.2
 django-taggit>=0.18.0

--- a/runtests.py
+++ b/runtests.py
@@ -19,6 +19,7 @@ if not settings.configured:
             'tests',
         ],
         MIDDLEWARE_CLASSES=[],
+        ROOT_URLCONF='taggit_selectize.urls',
     )
 
 

--- a/taggit_selectize/urls.py
+++ b/taggit_selectize/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import *
+from django.urls import path
 
 from .views import get_tags_recommendation
 
 urlpatterns = [
-    url(r'^$', get_tags_recommendation, name='tags_recommendation'),
+    path('', get_tags_recommendation, name='tags_recommendation'),
 ]

--- a/taggit_selectize/utils.py
+++ b/taggit_selectize/utils.py
@@ -1,6 +1,6 @@
 # Miscellaneous utilities
 import six
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from taggit.utils import split_strip
 from .conf import settings
 
@@ -20,7 +20,7 @@ def parse_tags(tagstring):
     if not tagstring:
         return []
 
-    tagstring = force_text(tagstring)
+    tagstring = force_str(tagstring)
 
     words = []
     buffer = []

--- a/taggit_selectize/widgets.py
+++ b/taggit_selectize/widgets.py
@@ -5,10 +5,8 @@ from taggit.utils import edit_string_for_tags
 
 from .conf import settings
 
-try:
-    from django.urls import reverse  # Django 1.10+
-except ImportError:
-    from django.core.urlresolvers import reverse
+from django.urls import reverse
+
 
 def bool_or_str(val):
    if val == True:

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,0 +1,9 @@
+from django.test import TestCase
+from django.urls import reverse
+
+
+class TestUrls(TestCase):
+    def test_urls(self):
+        response = self.client.get(reverse('tags_recommendation'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.request['PATH_INFO'], '/')


### PR DESCRIPTION
This addresses issues #37 and #38.
Also adding a test to cover urls.py as deprecation warnings was not showing during test due to lack of coverage.